### PR TITLE
Add copyright headers to remaining source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Pyroclast: Scalable Geophysics Models
+# https://github.com/MarcelFerrari/Pyroclast
+#
+# File: CMakeLists.txt
+# Description: Top-level CMake configuration orchestrating optional native builds.
+#
+# Author: Marcel Ferrari
+# Copyright (c) 2025 Marcel Ferrari.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 cmake_minimum_required(VERSION 3.20)
 project(PyroclastTurbo LANGUAGES CXX)
 

--- a/bin/pyroclast
+++ b/bin/pyroclast
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: bin/pyroclast
+Description: Command-line entry point for running Pyroclast simulations.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 import os
 import sys
 import argparse

--- a/bin/pyroclast
+++ b/bin/pyroclast
@@ -5,7 +5,7 @@ Pyroclast: Scalable Geophysics Models
 https://github.com/MarcelFerrari/Pyroclast
 
 File: bin/pyroclast
-Description: Command-line entry point for running Pyroclast simulations.
+Description: Command-line entry point for running the Pyroclast solver.
 
 Author: Marcel Ferrari
 Copyright (c) 2025 Marcel Ferrari.

--- a/examples/advection_2D/render_animation.py
+++ b/examples/advection_2D/render_animation.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: examples/advection_2D/render_animation.py
+Description: Render animation frames for the 2-D advection example outputs.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 import numpy as np
 import os
 import matplotlib.pyplot as plt

--- a/examples/stokes_2D/circular_inclusion/render_animation.py
+++ b/examples/stokes_2D/circular_inclusion/render_animation.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: examples/stokes_2D/circular_inclusion/render_animation.py
+Description: Render animation for the single circular inclusion Stokes example.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 import numpy as np
 import os
 import matplotlib.pyplot as plt

--- a/examples/stokes_2D/circular_inclusion_mg/render_animation.py
+++ b/examples/stokes_2D/circular_inclusion_mg/render_animation.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: examples/stokes_2D/circular_inclusion_mg/render_animation.py
+Description: Render animation for the multigrid circular inclusion example.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 import numpy as np
 import os
 import matplotlib.pyplot as plt

--- a/examples/stokes_2D/n_sink_benchmark/render_animation.py
+++ b/examples/stokes_2D/n_sink_benchmark/render_animation.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: examples/stokes_2D/n_sink_benchmark/render_animation.py
+Description: Render animation for the Stokes n-sink benchmark output frames.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 import numpy as np
 import os
 import matplotlib.pyplot as plt

--- a/pyroclast_turbo/CMakeLists.txt
+++ b/pyroclast_turbo/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Pyroclast: Scalable Geophysics Models
+# https://github.com/MarcelFerrari/Pyroclast
+#
+# File: pyroclast_turbo/CMakeLists.txt
+# Description: CMake configuration for building the Pyroclast Turbo extensions.
+#
+# Author: Marcel Ferrari
+# Copyright (c) 2025 Marcel Ferrari.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 cmake_minimum_required(VERSION 3.15...3.27)
 project(pyroclast_turbo LANGUAGES CXX)
 

--- a/pyroclast_turbo/include/pyroclast_turbo/init_bindings.hpp
+++ b/pyroclast_turbo/include/pyroclast_turbo/init_bindings.hpp
@@ -1,3 +1,16 @@
+// Pyroclast: Scalable Geophysics Models
+// https://github.com/MarcelFerrari/Pyroclast
+//
+// File: include/pyroclast_turbo/init_bindings.hpp
+// Description: Forward declarations for Pyroclast Turbo binding initializers.
+//
+// Author: Marcel Ferrari
+// Copyright (c) 2025 Marcel Ferrari.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #ifndef PYROCLAST_TURBO_INIT_BINDINGS_HPP
 #define PYROCLAST_TURBO_INIT_BINDINGS_HPP
 #include <nanobind/nanobind.h>

--- a/pyroclast_turbo/include/pyroclast_turbo/linear_interpolation_2D.hpp
+++ b/pyroclast_turbo/include/pyroclast_turbo/linear_interpolation_2D.hpp
@@ -1,3 +1,16 @@
+// Pyroclast: Scalable Geophysics Models
+// https://github.com/MarcelFerrari/Pyroclast
+//
+// File: include/pyroclast_turbo/linear_interpolation_2D.hpp
+// Description: Declarations for marker-to-grid linear interpolation kernels.
+//
+// Author: Marcel Ferrari
+// Copyright (c) 2025 Marcel Ferrari.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #ifndef PYROCLAST_TURBO_LINEAR_INTERPOLATION_2D
 #define PYROCLAST_TURBO_LINEAR_INTERPOLATION_2D
 

--- a/pyroclast_turbo/include/pyroclast_turbo/mg_routines.hpp
+++ b/pyroclast_turbo/include/pyroclast_turbo/mg_routines.hpp
@@ -1,3 +1,16 @@
+// Pyroclast: Scalable Geophysics Models
+// https://github.com/MarcelFerrari/Pyroclast
+//
+// File: include/pyroclast_turbo/mg_routines.hpp
+// Description: Declarations for multigrid transfer kernels.
+//
+// Author: Marcel Ferrari
+// Copyright (c) 2025 Marcel Ferrari.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #ifndef PYROCLAST_TURBO_MG_ROUTINES_HPP
 #define PYROCLAST_TURBO_MG_ROUTINES_HPP
 

--- a/pyroclast_turbo/include/pyroclast_turbo/utils.hpp
+++ b/pyroclast_turbo/include/pyroclast_turbo/utils.hpp
@@ -1,3 +1,16 @@
+// Pyroclast: Scalable Geophysics Models
+// https://github.com/MarcelFerrari/Pyroclast
+//
+// File: include/pyroclast_turbo/utils.hpp
+// Description: Utility helpers shared across Pyroclast Turbo kernels.
+//
+// Author: Marcel Ferrari
+// Copyright (c) 2025 Marcel Ferrari.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #ifndef PYROCLAST_TURBO_UTILS_HPP
 #define PYROCLAST_TURBO_UTILS_HPP
 

--- a/pyroclast_turbo/src/bindings/interpolation_bindings.cpp
+++ b/pyroclast_turbo/src/bindings/interpolation_bindings.cpp
@@ -1,4 +1,16 @@
-// interpolation_bindings.cpp
+// Pyroclast: Scalable Geophysics Models
+// https://github.com/MarcelFerrari/Pyroclast
+//
+// File: src/bindings/interpolation_bindings.cpp
+// Description: Nanobind adapters for linear interpolation kernels.
+//
+// Author: Marcel Ferrari
+// Copyright (c) 2025 Marcel Ferrari.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include "pyroclast_turbo/linear_interpolation_2D.hpp"

--- a/pyroclast_turbo/src/bindings/mg_routines_bindings.cpp
+++ b/pyroclast_turbo/src/bindings/mg_routines_bindings.cpp
@@ -1,4 +1,16 @@
-// mg_routines_bindings.cpp
+// Pyroclast: Scalable Geophysics Models
+// https://github.com/MarcelFerrari/Pyroclast
+//
+// File: src/bindings/mg_routines_bindings.cpp
+// Description: Nanobind wrappers exposing multigrid routines to Python.
+//
+// Author: Marcel Ferrari
+// Copyright (c) 2025 Marcel Ferrari.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include "pyroclast_turbo/mg_routines.hpp"

--- a/pyroclast_turbo/src/init_bindings.cpp
+++ b/pyroclast_turbo/src/init_bindings.cpp
@@ -1,4 +1,16 @@
-// init_bindings.cpp
+// Pyroclast: Scalable Geophysics Models
+// https://github.com/MarcelFerrari/Pyroclast
+//
+// File: src/init_bindings.cpp
+// Description: Module entry for registering all Pyroclast Turbo bindings.
+//
+// Author: Marcel Ferrari
+// Copyright (c) 2025 Marcel Ferrari.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #include <nanobind/nanobind.h>
 #include "pyroclast_turbo/init_bindings.hpp"
 

--- a/pyroclast_turbo/src/kernels/linear_interpolation_2D.cpp
+++ b/pyroclast_turbo/src/kernels/linear_interpolation_2D.cpp
@@ -1,3 +1,16 @@
+// Pyroclast: Scalable Geophysics Models
+// https://github.com/MarcelFerrari/Pyroclast
+//
+// File: src/kernels/linear_interpolation_2D.cpp
+// Description: CPU kernels for marker-grid linear interpolation routines.
+//
+// Author: Marcel Ferrari
+// Copyright (c) 2025 Marcel Ferrari.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #include <cmath>
 #include <algorithm>
 #include <omp.h>

--- a/pyroclast_turbo/src/kernels/mg_routines.cpp
+++ b/pyroclast_turbo/src/kernels/mg_routines.cpp
@@ -1,4 +1,16 @@
-// mg_routines.cpp
+// Pyroclast: Scalable Geophysics Models
+// https://github.com/MarcelFerrari/Pyroclast
+//
+// File: src/kernels/mg_routines.cpp
+// Description: CPU multigrid transfer kernels for Pyroclast Turbo.
+//
+// Author: Marcel Ferrari
+// Copyright (c) 2025 Marcel Ferrari.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #include <algorithm>
 #include <omp.h>
 #include "pyroclast_turbo/mg_routines.hpp"

--- a/share/setup-env.sh
+++ b/share/setup-env.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# Pyroclast: Scalable Geophysics Models
+# https://github.com/MarcelFerrari/Pyroclast
+#
+# File: share/setup-env.sh
+# Description: Convenience script to add Pyroclast binaries to the PATH.
+#
+# Author: Marcel Ferrari
+# Copyright (c) 2025 Marcel Ferrari.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 # Get the current directory where the script is located
 SCRIPT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 BIN_PATH=$(realpath "$SCRIPT_PATH/../bin/")

--- a/src/Pyroclast/arrayview.py
+++ b/src/Pyroclast/arrayview.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: arrayview.py
+Description: Context manager for CPU/GPU array transfers with intent semantics.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 import contextlib
 import numpy as np
 

--- a/src/Pyroclast/defaults.py
+++ b/src/Pyroclast/defaults.py
@@ -1,3 +1,19 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: defaults.py
+Description: Factory for default simulation configuration values.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
+
 def default_config():
     # Create a default configuration
     default_state = {

--- a/src/Pyroclast/gpu_utils.py
+++ b/src/Pyroclast/gpu_utils.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: gpu_utils.py
+Description: Helper utilities for GPU execution parameters and interoperability.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 # Attempt to import CuPy and Numba CUDA, set to None if not available
 try:
     import cupy as cp

--- a/src/Pyroclast/linalg.py
+++ b/src/Pyroclast/linalg.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: linalg.py
+Description: Device-aware linear algebra helpers for NumPy and CuPy arrays.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 import numpy as np
 
 try:

--- a/src/Pyroclast/logging.py
+++ b/src/Pyroclast/logging.py
@@ -1,4 +1,17 @@
-"""Central logging utilities with optional MPI support."""
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: logging.py
+Description: Central logging utilities with optional MPI integration.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
 
 import logging as py_logging
 

--- a/src/Pyroclast/profiling/__init__.py
+++ b/src/Pyroclast/profiling/__init__.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: profiling/__init__.py
+Description: Package exports for profiling utilities and shared timer instance.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 from .timer import Timer as _Timer
 
 # Global timer instance

--- a/src/Pyroclast/solvers/multigrid/__init__.py
+++ b/src/Pyroclast/solvers/multigrid/__init__.py
@@ -1,1 +1,16 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/multigrid/__init__.py
+Description: Package exports for multigrid solvers and helpers.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 from .multigrid import *

--- a/src/Pyroclast/solvers/multigrid/mg_routines.py
+++ b/src/Pyroclast/solvers/multigrid/mg_routines.py
@@ -1,3 +1,17 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/multigrid/mg_routines.py
+Description: CPU multigrid restriction and prolongation routines.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
 
 from Pyroclast.profiling import timer
 from Pyroclast.utils import clip

--- a/src/Pyroclast/solvers/multigrid/mg_routines_gpu.py
+++ b/src/Pyroclast/solvers/multigrid/mg_routines_gpu.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/multigrid/mg_routines_gpu.py
+Description: GPU kernels and helpers for multigrid transfer operators.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 from Pyroclast.gpu_utils import get_numba_stream, launch_2D
 import cupy as cp
 from numba import cuda

--- a/src/Pyroclast/solvers/stokes_2d/__init__.py
+++ b/src/Pyroclast/solvers/stokes_2d/__init__.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/__init__.py
+Description: Package exports for Stokes solvers and refinement utilities.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 """Stokes-specific multigrid solver wrappers."""
 
 from .uzawa_solver import UzawaSolver

--- a/src/Pyroclast/solvers/stokes_2d/implicit_operators/__init__.py
+++ b/src/Pyroclast/solvers/stokes_2d/implicit_operators/__init__.py
@@ -1,0 +1,15 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/implicit_operators/__init__.py
+Description: Package initializer for Stokes implicit operator backends.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+

--- a/src/Pyroclast/solvers/stokes_2d/implicit_operators/cpu/__init__.py
+++ b/src/Pyroclast/solvers/stokes_2d/implicit_operators/cpu/__init__.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/implicit_operators/cpu/__init__.py
+Description: CPU implicit operator exports for Stokes solvers.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 from .implicit_operators import (
     # ========= Operators =========
     vx_operator,

--- a/src/Pyroclast/solvers/stokes_2d/implicit_operators/gpu/__init__.py
+++ b/src/Pyroclast/solvers/stokes_2d/implicit_operators/gpu/__init__.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/implicit_operators/gpu/__init__.py
+Description: GPU implicit operator exports for Stokes solvers.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 from .implicit_operators import (
     # ========= Operators =========
     vx_operator,

--- a/src/Pyroclast/solvers/stokes_2d/iterative_refinement.py
+++ b/src/Pyroclast/solvers/stokes_2d/iterative_refinement.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/iterative_refinement.py
+Description: Iterative refinement wrapper for Uzawa-based Stokes solves.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 import numpy as np
 from Pyroclast.logging import get_logger
 from .smoothers.cpu.bc import apply_BC

--- a/src/Pyroclast/solvers/stokes_2d/smoothers/__init__.py
+++ b/src/Pyroclast/solvers/stokes_2d/smoothers/__init__.py
@@ -1,0 +1,15 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/smoothers/__init__.py
+Description: Package initializer for Stokes smoothing strategies.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+

--- a/src/Pyroclast/solvers/stokes_2d/smoothers/coeff.py
+++ b/src/Pyroclast/solvers/stokes_2d/smoothers/coeff.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/smoothers/coeff.py
+Description: Coefficient helpers for Stokes smoothing stencils.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 import numba as nb
 import numpy as np
 

--- a/src/Pyroclast/solvers/stokes_2d/smoothers/cpu/__init__.py
+++ b/src/Pyroclast/solvers/stokes_2d/smoothers/cpu/__init__.py
@@ -1,1 +1,16 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/smoothers/cpu/__init__.py
+Description: Package exports for CPU Stokes smoothing routines.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 from .jacobi import jacobi_velocity_smoother, pressure_sweep

--- a/src/Pyroclast/solvers/stokes_2d/smoothers/cpu/bc.py
+++ b/src/Pyroclast/solvers/stokes_2d/smoothers/cpu/bc.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/smoothers/cpu/bc.py
+Description: CPU boundary condition helpers for Stokes smoother fields.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 import numba as nb
 
 # ======== Utilities for boundary conditions ========

--- a/src/Pyroclast/solvers/stokes_2d/smoothers/cpu/jacobi.py
+++ b/src/Pyroclast/solvers/stokes_2d/smoothers/cpu/jacobi.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/smoothers/cpu/jacobi.py
+Description: CPU Jacobi smoothing routines for velocity and pressure updates.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 import numba as nb
 import numpy as np
 from .bc import apply_p_BC, apply_vx_BC, apply_vy_BC

--- a/src/Pyroclast/solvers/stokes_2d/smoothers/gpu/__init__.py
+++ b/src/Pyroclast/solvers/stokes_2d/smoothers/gpu/__init__.py
@@ -1,2 +1,17 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/smoothers/gpu/__init__.py
+Description: Package exports for GPU Stokes smoothing implementations.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 from .jacobi import jacobi_velocity_smoother, pressure_sweep
 from .jacobi_fused import jacobi_velocity_smoother_fused

--- a/src/Pyroclast/solvers/stokes_2d/smoothers/gpu/bc.py
+++ b/src/Pyroclast/solvers/stokes_2d/smoothers/gpu/bc.py
@@ -1,3 +1,17 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/smoothers/gpu/bc.py
+Description: GPU-friendly boundary condition helpers for Stokes smoothers.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
 
 # ======== Utilities for boundary conditions ========
 def apply_vx_BC(vx, BC):

--- a/src/Pyroclast/solvers/stokes_2d/smoothers/gpu/jacobi.py
+++ b/src/Pyroclast/solvers/stokes_2d/smoothers/gpu/jacobi.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/smoothers/gpu/jacobi.py
+Description: CUDA Jacobi smoothing kernels and launch wrappers for Stokes solves.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 from Pyroclast.gpu_utils import launch_2D, get_numba_stream
 import numba as nb
 from numba import cuda

--- a/src/Pyroclast/solvers/stokes_2d/smoothers/gpu/jacobi_fused.py
+++ b/src/Pyroclast/solvers/stokes_2d/smoothers/gpu/jacobi_fused.py
@@ -1,3 +1,18 @@
+"""
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/smoothers/gpu/jacobi_fused.py
+Description: Fused GPU Jacobi smoothers for coupled Stokes velocity-pressure updates.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
 from numba import cuda, types
 import cupy as cp
 import Pyroclast.gpu_utils as gpu_utils

--- a/src/Pyroclast/solvers/stokes_2d/velocity_multigrid_2D.py
+++ b/src/Pyroclast/solvers/stokes_2d/velocity_multigrid_2D.py
@@ -1,4 +1,19 @@
 """
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/velocity_multigrid_2D.py
+Description: Stokes-specific multigrid driver tying the hierarchy and smoothers.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
+"""
 Stokes-specific multigrid implementation.
 
 This module provides :class:`StokesMultigrid`, a concrete subclass of

--- a/src/Pyroclast/solvers/stokes_2d/viscosity_rescaler.py
+++ b/src/Pyroclast/solvers/stokes_2d/viscosity_rescaler.py
@@ -1,4 +1,19 @@
 """
+Pyroclast: Scalable Geophysics Models
+https://github.com/MarcelFerrari/Pyroclast
+
+File: solvers/stokes_2d/viscosity_rescaler.py
+Description: Utilities for optional viscosity rescaling during multigrid solves.
+
+Author: Marcel Ferrari
+Copyright (c) 2025 Marcel Ferrari.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
+"""
 Utilities for optional viscosity rescaling during the multigrid solve.
 """
 


### PR DESCRIPTION
## Summary
- add the Pyroclast MPL copyright banner to all Python modules that were missing it
- extend the same header to shell scripts, build scripts, and Pyroclast Turbo C++ sources so every file carries an author/description block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5e3034f30832598b9a6035706b582